### PR TITLE
Better diagnostics

### DIFF
--- a/tinjectlib/injectlib.cpp
+++ b/tinjectlib/injectlib.cpp
@@ -478,7 +478,7 @@ void InjectLib::InjectDLL(HANDLE processHandle
       moreThreads = Thread32Next(snapshot, &threadInfo);
     }
     if (injectThread != INVALID_HANDLE_VALUE) {
-      spdlog::get("usvfs")->info("going to inject dll");
+      spdlog::get("usvfs")->debug("going to inject dll");
       InjectDLLEIP(processHandle, injectThread, dllName,
                    initFunction, userData, userDataSize, skipInit);
     } else {

--- a/usvfs/hookcontext.cpp
+++ b/usvfs/hookcontext.cpp
@@ -60,7 +60,9 @@ USVFSParameters SharedParameters::makeLocal() const
   USVFSParameters result;
   USVFSInitParametersInt(&result, instanceName.c_str(),
                          currentSHMName.c_str(),
-                         currentInverseSHMName.c_str(), debugMode, logLevel);
+                         currentInverseSHMName.c_str(),
+                         debugMode, logLevel, crashDumpsType,
+                         crashDumpsPath.c_str());
   return result;
 }
 
@@ -70,13 +72,17 @@ void usvfs::USVFSInitParametersInt(USVFSParameters *parameters,
                                    const char *currentSHMName,
                                    const char *currentInverseSHMName,
                                    bool debugMode,
-                                   LogLevel logLevel)
+                                   LogLevel logLevel,
+                                   CrashDumpsType crashDumpsType,
+                                   const char *crashDumpsPath)
 {
   parameters->debugMode = debugMode;
   parameters->logLevel = logLevel;
-  strncpy_s(parameters->instanceName, 64, instanceName, _TRUNCATE);
-  strncpy_s(parameters->currentSHMName, 64, currentSHMName, _TRUNCATE);
-  strncpy_s(parameters->currentInverseSHMName, 64, currentInverseSHMName, _TRUNCATE);
+  parameters->crashDumpsType = crashDumpsType;
+  strncpy_s(parameters->instanceName, instanceName, _TRUNCATE);
+  strncpy_s(parameters->currentSHMName, currentSHMName, _TRUNCATE);
+  strncpy_s(parameters->currentInverseSHMName, currentInverseSHMName, _TRUNCATE);
+  strncpy_s(parameters->crashDumpsPath, crashDumpsPath, _TRUNCATE);
 }
 
 
@@ -162,12 +168,20 @@ HookContext::Ptr HookContext::writeAccess(const char*)
   return Ptr(s_Instance, unlock);
 }
 
+void HookContext::setLogLevel(LogLevel level)
+{
+  m_Parameters->logLevel = level;
+}
+
+void HookContext::setCrashDumpsType(CrashDumpsType type)
+{
+  m_Parameters->crashDumpsType = type;
+}
+
 void HookContext::updateParameters() const
 {
   m_Parameters->currentSHMName = m_Tree.shmName().c_str();
   m_Parameters->currentInverseSHMName = m_InverseTree.shmName().c_str();
-
-  m_Parameters->logLevel = usvfs::log::ConvertLogLevel(spdlog::get("usvfs")->level());
 }
 
 USVFSParameters HookContext::callParameters() const

--- a/usvfs/hookcontext.h
+++ b/usvfs/hookcontext.h
@@ -46,7 +46,9 @@ void USVFSInitParametersInt(USVFSParameters *parameters,
                             const char *currentSHMName,
                             const char *currentInverseSHMName,
                             bool debugMode,
-                            LogLevel logLevel);
+                            LogLevel logLevel,
+                            CrashDumpsType crashDumpsType,
+                            const char *crashDumpsPath);
 
 
 typedef shared::VoidAllocatorT::rebind<DWORD>::other DWORDAllocatorT;
@@ -67,6 +69,8 @@ struct SharedParameters {
     , currentInverseSHMName(reference.currentInverseSHMName, allocator)
     , debugMode(reference.debugMode)
     , logLevel(reference.logLevel)
+    , crashDumpsType(reference.crashDumpsType)
+    , crashDumpsPath(reference.crashDumpsPath, allocator)
     , userCount(1)
     , processBlacklist(allocator)
     , processList(allocator)
@@ -80,6 +84,8 @@ struct SharedParameters {
   shared::StringT currentInverseSHMName;
   bool debugMode;
   LogLevel logLevel;
+  CrashDumpsType crashDumpsType;
+  shared::StringT crashDumpsPath;
   uint32_t userCount;
   boost::container::flat_set<shared::StringT, std::less<shared::StringT>,
                              StringAllocatorT> processBlacklist;
@@ -193,6 +199,9 @@ public:
   std::vector<DWORD> registeredProcesses() const;
 
   void blacklistExecutable(const std::wstring &executableName);
+
+  void setLogLevel(LogLevel level);
+  void setCrashDumpsType(CrashDumpsType type);
 
   void updateParameters() const;
 

--- a/usvfs/hookmanager.cpp
+++ b/usvfs/hookmanager.cpp
@@ -58,6 +58,7 @@ HookManager::HookManager(const USVFSParameters &params, HMODULE module)
   s_Instance = this;
 
   m_Context.registerProcess(::GetCurrentProcessId());
+  spdlog::get("usvfs")->debug("Process registered in shared process list : {}",::GetCurrentProcessId());
 
   winapi::ex::OSVersion version = winapi::ex::getOSVersion();
   spdlog::get("usvfs")->info("Windows version {}.{} sp {}",

--- a/usvfs/usvfs.cpp
+++ b/usvfs/usvfs.cpp
@@ -153,10 +153,20 @@ extern "C" DLLEXPORT bool WINAPI GetLogMessages(char *buffer, size_t size,
   }
 }
 
-extern "C" DLLEXPORT void WINAPI SetLogLevel(LogLevel level)
+void SetLogLevel(LogLevel level)
 {
   spdlog::get("usvfs")->set_level(ConvertLogLevel(level));
   spdlog::get("hooks")->set_level(ConvertLogLevel(level));
+}
+
+extern "C" void WINAPI USVFSUpdateParams(LogLevel level, CrashDumpsType type)
+{
+  // update actual values used:
+  usvfs_dump_type = type;
+  SetLogLevel(level);
+  // update parameters in context so spawned process will inherit changes:
+  context->setLogLevel(level);
+  context->setCrashDumpsType(type);
 }
 
 //
@@ -651,15 +661,19 @@ VOID WINAPI PrintDebugInfo()
 
 void WINAPI USVFSInitParameters(USVFSParameters *parameters,
                                 const char *instanceName, bool debugMode,
-                                LogLevel logLevel)
+                                LogLevel logLevel,
+                                CrashDumpsType crashDumpsType,
+                                const char *crashDumpsPath)
 {
   parameters->debugMode = debugMode;
   parameters->logLevel = logLevel;
-  strncpy_s(parameters->instanceName, 64, instanceName, _TRUNCATE);
+  parameters->crashDumpsType = crashDumpsType;
+  strncpy_s(parameters->instanceName, instanceName, _TRUNCATE);
+  strncpy_s(parameters->crashDumpsPath, crashDumpsPath, _TRUNCATE);
   // we can't use the whole buffer as we need a few bytes to store a running
   // counter
   strncpy_s(parameters->currentSHMName, 60, instanceName, _TRUNCATE);
-  memset(parameters->currentInverseSHMName, '\0', 65);
+  memset(parameters->currentInverseSHMName, '\0', _countof(parameters->currentInverseSHMName));
   _snprintf(parameters->currentInverseSHMName, 60, "inv_%s", instanceName);
 }
 

--- a/usvfs/usvfs.h
+++ b/usvfs/usvfs.h
@@ -162,4 +162,6 @@ DLLEXPORT void WINAPI USVFSInitParameters(USVFSParameters *parameters,
                                           CrashDumpsType crashDumpsType,
                                           const char *crashDumpsPath);
 
+DLLEXPORT int WINAPI CreateMiniDump(PEXCEPTION_POINTERS exceptionPtrs, CrashDumpsType type, const wchar_t* dumpPath);
+
 }

--- a/usvfs/usvfs.h
+++ b/usvfs/usvfs.h
@@ -118,9 +118,9 @@ DLLEXPORT BOOL WINAPI CreateProcessHooked(
 DLLEXPORT bool WINAPI GetLogMessages(LPSTR buffer, size_t size, bool blocking = false);
 
 /**
- * @brief change the log level
+ * @brief Used to change parameters which can be changed in runtime
  */
-DLLEXPORT void WINAPI SetLogLevel(LogLevel level);
+DLLEXPORT void WINAPI USVFSUpdateParams(LogLevel level, CrashDumpsType type);
 
 /**
  * retrieves a readable representation of the vfs tree
@@ -157,6 +157,9 @@ DLLEXPORT void __cdecl InitHooks(LPVOID userData, size_t userDataSize);
 
 DLLEXPORT void WINAPI USVFSInitParameters(USVFSParameters *parameters,
                                           const char *instanceName,
-                                          bool debugMode, LogLevel logLevel);
+                                          bool debugMode,
+                                          LogLevel logLevel,
+                                          CrashDumpsType crashDumpsType,
+                                          const char *crashDumpsPath);
 
 }

--- a/usvfs/usvfsparameters.h
+++ b/usvfs/usvfsparameters.h
@@ -1,0 +1,4 @@
+// This file exists just to let projects which use usvfs access to the
+// the usvfs parameter type declarations
+
+#include "../usvfs_helper/usvfsparameters.h"

--- a/usvfs_helper/inject.cpp
+++ b/usvfs_helper/inject.cpp
@@ -99,6 +99,8 @@ void usvfs::injectProcess(const std::wstring &applicationPath
 
     InjectLib::InjectDLL(processHandle, threadHandle, dllPath.c_str(),
                          "InitHooks", &parameters, sizeof(USVFSParameters));
+
+    spdlog::get("usvfs")->info("injection to same bitness process {} successfull", ::GetProcessId(processHandle));
   } else {
     std::wstring exePath = (binPath / "usvfs_proxy.exe").wstring();
     if (!boost::filesystem::exists(exePath)) {

--- a/usvfs_helper/usvfsparameters.h
+++ b/usvfs_helper/usvfsparameters.h
@@ -23,9 +23,14 @@ along with usvfs. If not, see <http://www.gnu.org/licenses/>.
 #include "../shared/logging.h"
 #include "../usvfs/dllimport.h"
 
+enum class CrashDumpsType : uint8_t {
+  None,
+  Mini,
+  Data,
+  Full
+};
 
 extern "C" {
-
 
 struct USVFSParameters {
   char instanceName[65];
@@ -33,6 +38,8 @@ struct USVFSParameters {
   char currentInverseSHMName[65];
   bool debugMode{false};
   LogLevel logLevel{LogLevel::Debug};
+  CrashDumpsType crashDumpsType{CrashDumpsType::None};
+  char crashDumpsPath[260];
 };
 
 }

--- a/usvfs_test/main.cpp
+++ b/usvfs_test/main.cpp
@@ -102,7 +102,7 @@ public:
     InitLogging();
 
     USVFSParameters params;
-    USVFSInitParameters(&params, "usvfs_test", true, LogLevel::Debug);
+    USVFSInitParameters(&params, "usvfs_test", true, LogLevel::Debug, CrashDumpsType::None, "");
     m_Context.reset(CreateHookContext(params, ::GetModuleHandle(nullptr)));
     usvfs::RedirectionTreeContainer &tree = m_Context->redirectionTable();
     tree.addFile(ush::string_cast<std::string>(VIRTUAL_FILEW, ush::CodePage::UTF8).c_str()
@@ -126,7 +126,7 @@ class USVFSTestAuto : public testing::Test
 public:
   void SetUp() {
     USVFSParameters params;
-    USVFSInitParameters(&params, "usvfs_test_fixture", true, LogLevel::Debug);
+    USVFSInitParameters(&params, "usvfs_test_fixture", true, LogLevel::Debug, CrashDumpsType::None, "");
     ConnectVFS(&params);
     SHMLogger::create("usvfs");
   }
@@ -166,7 +166,7 @@ TEST_F(USVFSTest, CreateFileHookReportsCorrectErrorOnMissingFile)
 {
   EXPECT_NO_THROW({
     USVFSParameters params;
-    USVFSInitParameters(&params, "usvfs_test", true, LogLevel::Debug);
+    USVFSInitParameters(&params, "usvfs_test", true, LogLevel::Debug, CrashDumpsType::None, "");
     std::unique_ptr<usvfs::HookContext> ctx(CreateHookContext(params, ::GetModuleHandle(nullptr)));
     HANDLE res = uhooks::CreateFileW(VIRTUAL_FILEW
                                      , GENERIC_READ
@@ -199,7 +199,7 @@ TEST_F(USVFSTest, GetFileAttributesHookReportsCorrectErrorOnMissingFile)
   EXPECT_NO_THROW({
     try {
         USVFSParameters params;
-        USVFSInitParameters(&params, "usvfs_test", true, LogLevel::Debug);
+        USVFSInitParameters(&params, "usvfs_test", true, LogLevel::Debug, CrashDumpsType::None, "");
         std::unique_ptr<usvfs::HookContext> ctx(CreateHookContext(params, ::GetModuleHandle(nullptr)));
         DWORD res = uhooks::GetFileAttributesW(VIRTUAL_FILEW);
 
@@ -215,7 +215,7 @@ TEST_F(USVFSTest, GetFileAttributesHookReportsCorrectErrorOnMissingFile)
 TEST_F(USVFSTest, GetFileAttributesHookRedirectsFile)
 {
   USVFSParameters params;
-  USVFSInitParameters(&params, "usvfs_test", true, LogLevel::Debug);
+  USVFSInitParameters(&params, "usvfs_test", true, LogLevel::Debug, CrashDumpsType::None, "");
   std::unique_ptr<usvfs::HookContext> ctx(CreateHookContext(params, ::GetModuleHandle(nullptr)));
   usvfs::RedirectionTreeContainer &tree = ctx->redirectionTable();
 
@@ -229,7 +229,7 @@ TEST_F(USVFSTest, GetFileAttributesHookRedirectsFile)
 TEST_F(USVFSTest, GetFullPathNameOnRegularCurrentDirectory)
 {
   USVFSParameters params;
-  USVFSInitParameters(&params, "usvfs_test", true, LogLevel::Debug);
+  USVFSInitParameters(&params, "usvfs_test", true, LogLevel::Debug, CrashDumpsType::None, "");
   std::unique_ptr<usvfs::HookContext> ctx(CreateHookContext(params, ::GetModuleHandle(nullptr)));
 
   std::wstring expected = winapi::wide::getCurrentDirectory() + L"\\filename.txt";
@@ -247,7 +247,7 @@ TEST_F(USVFSTest, GetFullPathNameOnRegularCurrentDirectory)
 TEST_F(USVFSTest, NtQueryDirectoryFileRegularFile)
 {
   USVFSParameters params;
-  USVFSInitParameters(&params, "usvfs_test", true, LogLevel::Debug);
+  USVFSInitParameters(&params, "usvfs_test", true, LogLevel::Debug, CrashDumpsType::None, "");
   std::unique_ptr<usvfs::HookContext> ctx(CreateHookContext(params, ::GetModuleHandle(nullptr)));
 
   HANDLE hdl = CreateFileW(L"C:\\"
@@ -279,7 +279,7 @@ TEST_F(USVFSTest, NtQueryDirectoryFileRegularFile)
 TEST_F(USVFSTest, NtQueryDirectoryFileFindsVirtualFile)
 {
   USVFSParameters params;
-  USVFSInitParameters(&params, "usvfs_test", true, LogLevel::Debug);
+  USVFSInitParameters(&params, "usvfs_test", true, LogLevel::Debug, CrashDumpsType::None, "");
   std::unique_ptr<usvfs::HookContext> ctx(CreateHookContext(params, ::GetModuleHandle(nullptr)));
   usvfs::RedirectionTreeContainer &tree = ctx->redirectionTable();
 


### PR DESCRIPTION
Tweaks to improve diagnostics including ability to generate data and full crash dumps and hopefully less chance the VEHandler itself crashes when attempting to report a crash.
You will also need my changes to modorganizer as this changes the interface between the modorganizer exe and usvfs dll.