### PR TITLE
add info print when process registers

### DIFF
--- a/usvfs/hookmanager.cpp
+++ b/usvfs/hookmanager.cpp
@@ -58,7 +58,7 @@ HookManager::HookManager(const USVFSParameters &params, HMODULE module)
   s_Instance = this;
 
   m_Context.registerProcess(::GetCurrentProcessId());
-  spdlog::get("usvfs")->debug("Process registered in shared process list : {}",::GetCurrentProcessId());
+  spdlog::get("usvfs")->info("Process registered in shared process list : {}",::GetCurrentProcessId());
 
   winapi::ex::OSVersion version = winapi::ex::getOSVersion();
   spdlog::get("usvfs")->info("Windows version {}.{} sp {}",


### PR DESCRIPTION
stupid change but the whole point is that we will see that print when we suspect the registration was too late and I don't want to rely that the user is using debug logs... 